### PR TITLE
Fix Excel session export header alignment for dumpOnefile

### DIFF
--- a/services.py
+++ b/services.py
@@ -318,12 +318,9 @@ def export_sessions(auth_token: str, user_id: str, dump_one_file: bool, products
             else:
                 for row in sessions:
                     if ws.max_row == 1:
-                        ws.append(list(row.keys()))
-                    if 'parent' in row:
-                        del row['parent']
-                    if 'sched_hints' in row:
-                        del row['sched_hints']
-                    ws.append(list(row.values()))
+                        ws.append(fieldnames)
+                    row_data = [row.get(column, "") for column in fieldnames]
+                    ws.append(row_data)
 
     if dump_one_file:
         if ws.max_row > 1:


### PR DESCRIPTION
## Summary
- ensure the dumpOnefile export uses the defined field list when writing Excel output so headers line up with row data

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d79f7609ac832c9a1e74018eb4a698